### PR TITLE
Update for Swift 2.2 (Xcode 7.3 and later)

### DIFF
--- a/Classes/WDCropBorderView.swift
+++ b/Classes/WDCropBorderView.swift
@@ -18,7 +18,7 @@ internal class WDCropBorderView: UIView {
         self.backgroundColor = UIColor.clearColor()
     }
 
-    required init(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
 
         self.backgroundColor = UIColor.clearColor()

--- a/Classes/WDImageCropOverlayView.swift
+++ b/Classes/WDImageCropOverlayView.swift
@@ -20,7 +20,7 @@ internal class WDImageCropOverlayView: UIView {
         self.userInteractionEnabled = true
     }
 
-    required init(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
 
         self.backgroundColor = UIColor.clearColor()

--- a/Classes/WDImageCropView.swift
+++ b/Classes/WDImageCropView.swift
@@ -107,7 +107,7 @@ internal class WDImageCropView: UIView, UIScrollViewDelegate {
         self.scrollView.setZoomScale(1.0, animated: false)
     }
 
-    required init(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
 
@@ -144,7 +144,7 @@ internal class WDImageCropView: UIView, UIScrollViewDelegate {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        var size = self.cropSize;
+        let size = self.cropSize;
         let toolbarSize = CGFloat(UIDevice.currentDevice().userInterfaceIdiom == .Pad ? 0 : 54)
         self.xOffset = floor((CGRectGetWidth(self.bounds) - size.width) * 0.5)
         self.yOffset = floor((CGRectGetHeight(self.bounds) - toolbarSize - size.height) * 0.5)
@@ -188,10 +188,10 @@ internal class WDImageCropView: UIView, UIScrollViewDelegate {
 
         // finally crop image
         let imageRef = CGImageCreateWithImageInRect(imageToCrop!.CGImage, visibleRect)
-        let result = UIImage(CGImage: imageRef, scale: imageToCrop!.scale,
+        let result = UIImage(CGImage: imageRef!, scale: imageToCrop!.scale,
             orientation: imageToCrop!.imageOrientation)
 
-        return result!
+        return result
     }
 
     private func calcVisibleRectForResizeableCropArea() -> CGRect {

--- a/Classes/WDImageCropViewController.swift
+++ b/Classes/WDImageCropViewController.swift
@@ -63,9 +63,9 @@ internal class WDImageCropViewController: UIViewController {
 
     private func setupNavigationBar() {
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel,
-            target: self, action: "actionCancel:")
+                                                                target: self, action: #selector(actionCancel))
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Use", style: .Plain,
-            target: self, action: "actionUse:")
+            target: self, action: #selector(actionUse))
     }
 
     private func setupCropView() {
@@ -84,7 +84,7 @@ internal class WDImageCropViewController: UIViewController {
         self.cancelButton.setTitle("Cancel", forState: .Normal)
         self.cancelButton.setTitleShadowColor(
             UIColor(red: 0.118, green: 0.247, blue: 0.455, alpha: 1), forState: .Normal)
-        self.cancelButton.addTarget(self, action: "actionCancel:", forControlEvents: .TouchUpInside)
+        self.cancelButton.addTarget(self, action: #selector(actionCancel), forControlEvents: .TouchUpInside)
     }
 
     private func setupUseButton() {
@@ -95,7 +95,7 @@ internal class WDImageCropViewController: UIViewController {
         self.useButton.setTitle("Use", forState: .Normal)
         self.useButton.setTitleShadowColor(
             UIColor(red: 0.118, green: 0.247, blue: 0.455, alpha: 1), forState: .Normal)
-        self.useButton.addTarget(self, action: "actionUse:", forControlEvents: .TouchUpInside)
+        self.useButton.addTarget(self, action: #selector(actionUse), forControlEvents: .TouchUpInside)
     }
 
     private func toolbarBackgroundImage() -> UIImage {
@@ -107,8 +107,7 @@ internal class WDImageCropViewController: UIViewController {
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let gradient = CGGradientCreateWithColorComponents(colorSpace, components, nil, 2)
 
-        CGContextDrawLinearGradient(context, gradient, CGPointMake(0, 0), CGPointMake(0, 54),
-            .allZeros)
+        CGContextDrawLinearGradient(context, gradient, CGPointMake(0, 0), CGPointMake(0, 54), [])
 
         let viewImage = UIGraphicsGetImageFromCurrentImageContext()
 

--- a/Classes/WDImagePicker.swift
+++ b/Classes/WDImagePicker.swift
@@ -45,7 +45,7 @@ import UIKit
         }
     }
 
-    public func imagePickerController(picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [NSObject : AnyObject]) {
+    public func imagePickerController(picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : AnyObject]) {
         let cropController = WDImageCropViewController()
         cropController.sourceImage = info[UIImagePickerControllerOriginalImage] as! UIImage
         cropController.resizableCropArea = self.resizableCropArea

--- a/Classes/WDResizableCropOverlayView.swift
+++ b/Classes/WDResizableCropOverlayView.swift
@@ -59,7 +59,7 @@ internal class WDResizableCropOverlayView: WDImageCropOverlayView {
         self.addContentViews()
     }
 
-    required init(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
 
@@ -67,8 +67,8 @@ internal class WDResizableCropOverlayView: WDImageCropOverlayView {
         super.init(frame: frame)
     }
 
-    override func touchesBegan(touches: Set<NSObject>, withEvent event: UIEvent) {
-        if let touch = touches.first as? UITouch {
+    override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
+        if let touch = touches.first {
             let touchPoint = touch.locationInView(cropBorderView)
 
             anchor = self.calculateAnchorBorder(touchPoint)
@@ -78,8 +78,8 @@ internal class WDResizableCropOverlayView: WDImageCropOverlayView {
         }
     }
 
-    override func touchesMoved(touches: Set<NSObject>, withEvent event: UIEvent) {
-        if let touch = touches.first as? UITouch {
+    override func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent?) {
+        if let touch = touches.first {
             if resizingEnabled! {
                 self.resizeWithTouchPoint(touch.locationInView(self.superview))
             }

--- a/WDImagePicker.xcodeproj/project.pbxproj
+++ b/WDImagePicker.xcodeproj/project.pbxproj
@@ -182,6 +182,8 @@
 		764FD5791B8F01C100BE5F46 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0730;
+				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0640;
 				ORGANIZATIONNAME = "Wu Di";
 				TargetAttributes = {
@@ -443,6 +445,7 @@
 				764FD5A21B8F01C100BE5F46 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		764FD5A31B8F01C100BE5F46 /* Build configuration list for PBXNativeTarget "WDImagePickerTests" */ = {
 			isa = XCConfigurationList;
@@ -451,6 +454,7 @@
 				764FD5A51B8F01C100BE5F46 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
Updates syntax for Swift 2.2, I did notice that you can't move the crop box for the Resizable Custom Crop. I don't know if this was a pre-existing bug as I don't have an older version of XCode to run the older swift syntax.

The tests passed :wink:
